### PR TITLE
update

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,10 +15,18 @@ jobs:
           operations-per-run: 60
           days-before-issue-stale: 60
           days-before-issue-close: 30
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue is stale because it has been open for 60 days with no activity.
+            It will be closed in 30 days on inactivity.
+          close-issue-message: |
+            This issue was closed because it has been inactive for 30 days since being marked as stale.
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-issue-labels: "in-progress,assigned,kind/enhancement"
+          exempt-all-assignees: true
+          exempt-issue-labels: >-
+            in-progress,
+            assigned,
+            kind/bug,
+            kind/enhancement

--- a/cmd/agent/docker_credentials.go
+++ b/cmd/agent/docker_credentials.go
@@ -6,14 +6,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/loft-sh/devpod/cmd/agent/container"
 	"github.com/loft-sh/devpod/cmd/flags"
 	"github.com/loft-sh/devpod/pkg/dockercredentials"
 	devpodhttp "github.com/loft-sh/devpod/pkg/http"
+	"github.com/loft-sh/devpod/pkg/ts"
 	"github.com/loft-sh/log"
 	"github.com/spf13/cobra"
 )
@@ -111,6 +116,17 @@ func (cmd *DockerCredentialsCmd) handleGet(log log.Logger) error {
 		return fmt.Errorf("no credentials server URL")
 	}
 
+	credentials := getDockerCredentialsFromWorkspaceServer(&dockercredentials.Credentials{ServerURL: strings.TrimSpace(string(url))})
+	if credentials != nil {
+		raw, err := json.Marshal(credentials)
+		if err != nil {
+			log.Errorf("Error encoding credentials: %v", err)
+			return nil
+		}
+		fmt.Print(string(raw))
+		return nil
+	}
+
 	rawJSON, err := json.Marshal(&dockercredentials.Request{ServerURL: strings.TrimSpace(string(url))})
 	if err != nil {
 		return err
@@ -145,4 +161,66 @@ func (cmd *DockerCredentialsCmd) handleGet(log log.Logger) error {
 	// print response to stdout
 	fmt.Print(string(raw))
 	return nil
+}
+
+func getDockerCredentialsFromWorkspaceServer(credentials *dockercredentials.Credentials) *dockercredentials.Credentials {
+	if _, err := os.Stat(filepath.Join(container.RootDir, ts.RunnerProxySocket)); err != nil {
+		// workspace server is not running
+		return nil
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", filepath.Join(container.RootDir, ts.RunnerProxySocket))
+			},
+		},
+		Timeout: 15 * time.Second,
+	}
+
+	credentials, credentialsErr := requestDockerCredentials(httpClient, credentials, "http://runner-proxy/docker-credentials")
+	if credentialsErr != nil {
+		// append error to /var/devpod/docker-credentials.log
+		file, err := os.OpenFile("/var/devpod/docker-credentials-error.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return nil
+		}
+		defer file.Close()
+
+		_, _ = file.WriteString(fmt.Sprintf("get credentials from workspace server: %v\n", credentialsErr))
+		return nil
+	}
+
+	return credentials
+}
+
+func requestDockerCredentials(httpClient *http.Client, credentials *dockercredentials.Credentials, url string) (*dockercredentials.Credentials, error) {
+	rawJSON, err := json.Marshal(credentials)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling credentials: %w", err)
+	}
+
+	response, err := httpClient.Post(url, "application/json", bytes.NewReader(rawJSON))
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving credentials from credentials server: %w", err)
+	}
+	defer response.Body.Close()
+
+	raw, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading credentials: %w", err)
+	}
+
+	// has the request succeeded?
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error reading credentials (%d): %s", response.StatusCode, string(raw))
+	}
+
+	credentials = &dockercredentials.Credentials{}
+	err = json.Unmarshal(raw, credentials)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding credentials: %w", err)
+	}
+
+	return credentials, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -161,7 +161,7 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
 github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -554,7 +554,7 @@ github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/protoc-gen-gogo/descriptor
 github.com/gogo/protobuf/sortkeys
-# github.com/golang-jwt/jwt/v4 v4.5.1
+# github.com/golang-jwt/jwt/v4 v4.5.2
 ## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
 # github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da


### PR DESCRIPTION
This pull request introduces support for retrieving Docker credentials from the workspace server, alongside several related enhancements and minor dependency updates. The main focus is to enable the agent to fetch Docker credentials via an HTTP endpoint, improving integration with workspace environments. Additional changes include updating workflow configuration and a dependency version bump.

### Docker Credentials Integration

* Added logic in `cmd/agent/docker_credentials.go` to retrieve Docker credentials from the workspace server via a new HTTP endpoint, including error handling and logging for failed credential retrievals. [[1]](diffhunk://#diff-0c7ec0bb5195981f77d8f80ad6d633e7ca1d56c1168602565002628a3551e7ceR119-R129) [[2]](diffhunk://#diff-0c7ec0bb5195981f77d8f80ad6d633e7ca1d56c1168602565002628a3551e7ceR165-R226)
* Implemented the `/docker-credentials` HTTP route in `pkg/daemon/platform/local_server.go` to serve Docker credentials for a given registry, and registered the route in the local server. [[1]](diffhunk://#diff-e3c8ad856a1c2bbcdee244b949ec263aad71d50f5d29e4449046ab0ed25338a3R87) [[2]](diffhunk://#diff-e3c8ad856a1c2bbcdee244b949ec263aad71d50f5d29e4449046ab0ed25338a3R122) [[3]](diffhunk://#diff-e3c8ad856a1c2bbcdee244b949ec263aad71d50f5d29e4449046ab0ed25338a3R619-R639)
* Created a reverse proxy handler in `pkg/ts/workspace_server.go` for forwarding Docker credential requests to the appropriate runner, similar to existing Git credentials handling. [[1]](diffhunk://#diff-a69c5ff384a382d6e655ec43fff474c60e1ba47622048dedbf8d839516563d0cR248-R259) [[2]](diffhunk://#diff-a69c5ff384a382d6e655ec43fff474c60e1ba47622048dedbf8d839516563d0cR329-R359)

### Dependency Updates

* Updated `github.com/golang-jwt/jwt/v4` from v4.5.1 to v4.5.2 in `go.mod`.

### Workflow Configuration

* Improved `.github/workflows/stale.yaml` with clearer messages, added support for exempting issues with any assignee, and expanded exempt labels to include `kind/bug`.

### Miscellaneous

* Added missing imports in `cmd/agent/docker_credentials.go` and `pkg/daemon/platform/local_server.go` to support new functionality. [[1]](diffhunk://#diff-0c7ec0bb5195981f77d8f80ad6d633e7ca1d56c1168602565002628a3551e7ceR9-R21) [[2]](diffhunk://#diff-e3c8ad856a1c2bbcdee244b949ec263aad71d50f5d29e4449046ab0ed25338a3R16) [[3]](diffhunk://#diff-e3c8ad856a1c2bbcdee244b949ec263aad71d50f5d29e4449046ab0ed25338a3R25)
* Updated comments in `pkg/ts/workspace_server.go` for clarity regarding credential handlers.